### PR TITLE
Decrease timeout for TTL cache

### DIFF
--- a/app.py
+++ b/app.py
@@ -72,7 +72,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-cache = TTLCache(maxsize=500, ttl=86400)
+cache = TTLCache(maxsize=500, ttl=3600)
 
 
 def get_data_from_cache(key):


### PR DESCRIPTION
In some cases before the new day's data finishes generating, new date ranges become associated with stale data for the next 24 hours